### PR TITLE
Melhorias e novas funcionalidades para o conversor PlantUML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Diretório de saída padrão
+/output/
+
+# Arquivos temporários
+*.tmp
+*.temp
+
+# Arquivos gerados
+*.png
+
+# Arquivos do sistema
+.DS_Store
+Thumbs.db
+
+# Arquivos de configuração específicos do usuário
+*.jar

--- a/README.md
+++ b/README.md
@@ -1,2 +1,96 @@
-# generate_png_plantuml
+# PlantUML 2 PNG
+
 Utilitário para gerar arquivos PNG a partir de diagramas PlantUML (.wsd)
+
+## Descrição
+
+Este utilitário permite converter arquivos de diagrama PlantUML (.wsd) em imagens PNG, facilitando a visualização e inclusão em documentos. 
+
+Ele oferece:
+- Conversão individual de diagramas
+- Processamento em lote de múltiplos diagramas
+- Download automático do JAR do PlantUML (se necessário)
+- Configuração de diretório de saída personalizado
+
+## Requisitos
+
+- Java (JRE 8 ou superior)
+- Bash (Linux, macOS, ou Windows com WSL/Git Bash)
+- Acesso à internet (para o download automático do PlantUML JAR na primeira execução)
+
+## Instalação
+
+```bash
+# Clone o repositório
+git clone https://github.com/tiagonpsilva/plantuml_2_png.git
+
+# Entre no diretório
+cd plantuml_2_png
+
+# Torne os scripts executáveis
+chmod +x plantuml2png.sh batch-convert.sh
+```
+
+## Uso
+
+### Conversão de um único arquivo
+
+```bash
+./plantuml2png.sh [OPÇÕES] <arquivo.wsd>
+```
+
+Opções:
+- `-h, --help` - Exibe a mensagem de ajuda
+- `-v, --verbose` - Modo detalhado, exibe mais informações durante a execução
+- `-V, --version` - Exibe a versão do script
+- `-o, --output-dir DIR` - Define o diretório de saída para os arquivos PNG gerados
+
+Exemplos:
+```bash
+# Conversão simples
+./plantuml2png.sh diagrama.wsd
+
+# Conversão com diretório de saída personalizado
+./plantuml2png.sh -o imagens/ diagrama.wsd
+
+# Conversão em modo detalhado
+./plantuml2png.sh -v diagrama.wsd
+```
+
+### Conversão em lote
+
+```bash
+./batch-convert.sh [DIRETÓRIO_SAÍDA] [DIRETÓRIO_ENTRADA] [--verbose]
+```
+
+Parâmetros:
+- `DIRETÓRIO_SAÍDA` - Diretório onde os PNGs serão salvos (padrão: ./output)
+- `DIRETÓRIO_ENTRADA` - Diretório onde os arquivos .wsd serão lidos (padrão: ./examples)
+- `--verbose` - Exibe informações detalhadas durante o processamento
+
+Exemplos:
+```bash
+# Usar configurações padrão
+./batch-convert.sh
+
+# Personalizar diretório de saída
+./batch-convert.sh ./diagramas
+
+# Personalizar diretórios de entrada e saída
+./batch-convert.sh ./diagramas ./src
+```
+
+## Estrutura do Projeto
+
+- `plantuml2png.sh` - Script principal para conversão de arquivos individuais
+- `batch-convert.sh` - Script para processamento em lote
+- `examples/` - Diretório com exemplos de diagramas PlantUML
+- `output/` - Diretório padrão para armazenar os PNGs gerados (criado automaticamente)
+
+## Licença
+
+Este projeto é distribuído sob a licença MIT.
+
+## Autor
+
+Tiago N. Pinto Silva

--- a/batch-convert.sh
+++ b/batch-convert.sh
@@ -2,44 +2,122 @@
 
 # batch-convert.sh - Script para converter múltiplos arquivos PlantUML de uma vez
 # Autor: Tiago N. Pinto Silva
-# Versão: 1.0.0
+# Versão: 1.1.0
 
-# Pasta onde os PNGs serão salvos (padrão: ./output)
+# ===========================
+# Configurações
+# ===========================
+# Pasta onde os arquivos serão salvos (padrão: ./output)
 OUTPUT_DIR="${1:-./output}"
 # Pasta com os arquivos de origem (padrão: ./examples)
 INPUT_DIR="${2:-./examples}"
 # Flag de verbosidade
 VERBOSE=0
+# Formato de saída (padrão: png)
+OUTPUT_FORMAT="png"
+# Caminho personalizado para o JAR do PlantUML (padrão: usar o do script principal)
+PLANTUML_JAR_PATH=""
+# Extensões de arquivo a processar
+FILE_EXTENSIONS=("wsd" "puml" "plantuml" "iuml" "pu")
+
+# ===========================
+# Funções
+# ===========================
 
 # Função para exibir mensagem de ajuda
 show_help() {
-  echo "Uso: $(basename $0) [DIRETÓRIO_SAÍDA] [DIRETÓRIO_ENTRADA] [--verbose]"
+  echo "Uso: $(basename $0) [OPÇÕES] [DIRETÓRIO_SAÍDA] [DIRETÓRIO_ENTRADA]"
   echo
-  echo "Converte todos os arquivos .wsd do diretório de entrada para PNG"
+  echo "Converte todos os arquivos de diagrama PlantUML do diretório de entrada para o formato especificado"
   echo
-  echo "Parâmetros:"
-  echo "  DIRETÓRIO_SAÍDA   Diretório onde os PNGs serão salvos (padrão: ./output)"
-  echo "  DIRETÓRIO_ENTRADA Diretório de onde os arquivos .wsd serão lidos (padrão: ./examples)"
-  echo "  --verbose         Exibe informações detalhadas durante o processamento"
+  echo "Parâmetros posicionais (opcionais):"
+  echo "  DIRETÓRIO_SAÍDA    Diretório onde os arquivos serão salvos (padrão: ./output)"
+  echo "  DIRETÓRIO_ENTRADA  Diretório de onde os arquivos serão lidos (padrão: ./examples)"
+  echo
+  echo "Opções:"
+  echo "  -h, --help              Exibe esta mensagem de ajuda"
+  echo "  -v, --verbose           Exibe informações detalhadas durante o processamento"
+  echo "  -f, --format FORMAT     Define o formato de saída (png, svg, eps, pdf) [padrão: png]"
+  echo "  -j, --jar-path PATH     Define um caminho personalizado para o arquivo PlantUML JAR"
+  echo "  -e, --extension EXT     Especifica extensão adicional para processar (pode ser usado múltiplas vezes)"
+  echo "                          Extensões padrão: ${FILE_EXTENSIONS[*]}"
   echo
   echo "Exemplos:"
-  echo "  $(basename $0)                       # Usa ./examples como entrada e ./output como saída"
-  echo "  $(basename $0) ./diagramas           # Usa ./examples como entrada e ./diagramas como saída"
-  echo "  $(basename $0) ./diagramas ./src     # Usa ./src como entrada e ./diagramas como saída"
-  echo "  $(basename $0) ./diagramas ./src --verbose  # Modo verboso"
+  echo "  $(basename $0)                        # Usa ./examples como entrada e ./output como saída"
+  echo "  $(basename $0) ./diagramas            # Usa ./examples como entrada e ./diagramas como saída"
+  echo "  $(basename $0) ./diagramas ./src      # Usa ./src como entrada e ./diagramas como saída"
+  echo "  $(basename $0) -f svg ./diagramas     # Gera arquivos SVG em vez de PNG"
+  echo "  $(basename $0) --verbose -f pdf       # Modo verbose com saída em PDF"
   echo
   exit 0
 }
 
-# Verifica a presença de --help
-for arg in "$@"; do
-  if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-    show_help
-  fi
-  if [[ "$arg" == "--verbose" || "$arg" == "-v" ]]; then
-    VERBOSE=1
-  fi
+# ===========================
+# Processamento de argumentos
+# ===========================
+
+# Array para armazenar argumentos não processados
+NON_OPTION_ARGS=()
+
+# Processa todos os argumentos da linha de comando
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      show_help
+      ;;
+    -v|--verbose)
+      VERBOSE=1
+      shift
+      ;;
+    -f|--format)
+      if [[ -n "$2" && "$2" != -* ]]; then
+        case "$2" in
+          png|svg|eps|pdf)
+            OUTPUT_FORMAT="$2"
+            shift 2
+            ;;
+          *)
+            echo "❌ Erro: Formato de saída inválido: $2. Formatos suportados: png, svg, eps, pdf"
+            exit 1
+            ;;
+        esac
+      else
+        echo "❌ Erro: Argumento ausente para a opção $1"
+        exit 1
+      fi
+      ;;
+    -j|--jar-path)
+      if [[ -n "$2" && "$2" != -* ]]; then
+        PLANTUML_JAR_PATH="$2"
+        shift 2
+      else
+        echo "❌ Erro: Argumento ausente para a opção $1"
+        exit 1
+      fi
+      ;;
+    -e|--extension)
+      if [[ -n "$2" && "$2" != -* ]]; then
+        FILE_EXTENSIONS+=("$2")
+        shift 2
+      else
+        echo "❌ Erro: Argumento ausente para a opção $1"
+        exit 1
+      fi
+      ;;
+    *)
+      NON_OPTION_ARGS+=("$1")
+      shift
+      ;;
+  esac
 done
+
+# Restaura os argumentos posicionais se fornecidos
+if [[ ${#NON_OPTION_ARGS[@]} -ge 1 ]]; then
+  OUTPUT_DIR="${NON_OPTION_ARGS[0]}"
+fi
+if [[ ${#NON_OPTION_ARGS[@]} -ge 2 ]]; then
+  INPUT_DIR="${NON_OPTION_ARGS[1]}"
+fi
 
 # Verifica se o diretório de entrada existe
 if [ ! -d "$INPUT_DIR" ]; then
@@ -63,40 +141,50 @@ fi
 # Adiciona permissão de execução ao script se necessário
 chmod +x "$PLANTUML_SCRIPT"
 
-# Encontra todos os arquivos .wsd no diretório de entrada
-WSD_FILES=$(find "$INPUT_DIR" -name "*.wsd" -type f)
+# Constrói o padrão de extensões para usar com find
+EXTENSION_PATTERN=$(IFS="|"; echo "${FILE_EXTENSIONS[*]}")
+
+# Encontra todos os arquivos de diagrama no diretório de entrada
+DIAGRAM_FILES=$(find "$INPUT_DIR" -type f -regextype posix-extended -regex ".*\.($EXTENSION_PATTERN)$")
 
 # Verifica se encontrou arquivos
-if [ -z "$WSD_FILES" ]; then
-  echo "⚠️ Aviso: Nenhum arquivo .wsd encontrado no diretório '$INPUT_DIR'."
+if [ -z "$DIAGRAM_FILES" ]; then
+  echo "⚠️ Aviso: Nenhum arquivo de diagrama encontrado no diretório '$INPUT_DIR'."
+  echo "   Extensões pesquisadas: ${FILE_EXTENSIONS[*]}"
   exit 0
 fi
 
 # Contador de arquivos
-TOTAL_FILES=$(echo "$WSD_FILES" | wc -l)
+TOTAL_FILES=$(echo "$DIAGRAM_FILES" | wc -l)
 CURRENT=0
 SUCCESS=0
 FAILED=0
 
-echo "🔍 Encontrados $TOTAL_FILES arquivos .wsd para conversão"
+echo "📋 Encontrados $TOTAL_FILES arquivos para conversão"
 echo "📁 Diretório de saída: $OUTPUT_DIR"
+echo "🖼️ Formato de saída: $OUTPUT_FORMAT"
 echo "🚀 Iniciando processamento..."
 
+# Prepara as opções para o script plantuml2png.sh
+SCRIPT_OPTS="--output-dir \"$OUTPUT_DIR\" --format $OUTPUT_FORMAT"
+
+if [ $VERBOSE -eq 1 ]; then
+  SCRIPT_OPTS="$SCRIPT_OPTS --verbose"
+fi
+
+if [ -n "$PLANTUML_JAR_PATH" ]; then
+  SCRIPT_OPTS="$SCRIPT_OPTS --jar-path \"$PLANTUML_JAR_PATH\""
+fi
+
 # Processa cada arquivo
-for wsd_file in $WSD_FILES; do
+for diagram_file in $DIAGRAM_FILES; do
   CURRENT=$((CURRENT + 1))
-  FILENAME=$(basename "$wsd_file")
+  FILENAME=$(basename "$diagram_file")
   
   echo "[$CURRENT/$TOTAL_FILES] Processando $FILENAME..."
   
-  # Define as opções com base na verbosidade
-  OPTS=""
-  if [ $VERBOSE -eq 1 ]; then
-    OPTS="--verbose"
-  fi
-  
   # Executa a conversão
-  "$PLANTUML_SCRIPT" $OPTS --output-dir "$OUTPUT_DIR" "$wsd_file"
+  eval "$PLANTUML_SCRIPT $SCRIPT_OPTS \"$diagram_file\""
   
   # Verifica o resultado
   if [ $? -eq 0 ]; then
@@ -107,18 +195,18 @@ for wsd_file in $WSD_FILES; do
     echo "❌ [$CURRENT/$TOTAL_FILES] Falha ao converter $FILENAME"
   fi
   
-  echo "-------------------------------------------"
+  echo "----------------------------------------"
 done
 
 # Mostra resumo
-echo "🏁 Processamento concluído!"
+echo "🎯 Processamento concluído!"
 echo "📊 Resumo:"
 echo "   - Total de arquivos: $TOTAL_FILES"
 echo "   - Convertidos com sucesso: $SUCCESS"
 echo "   - Falhas: $FAILED"
 
 if [ $SUCCESS -gt 0 ]; then
-  echo "📂 Os arquivos PNG estão disponíveis em: $OUTPUT_DIR"
+  echo "📂 Os arquivos $OUTPUT_FORMAT estão disponíveis em: $OUTPUT_DIR"
 fi
 
 exit 0

--- a/examples/activity-diagram.wsd
+++ b/examples/activity-diagram.wsd
@@ -1,0 +1,63 @@
+@startuml Activity Diagram Example
+title Fluxo de Processamento de Pedidos
+
+|Cliente|
+start
+:Adicionar itens ao carrinho;
+:Revisar pedido;
+:Confirmar pedido;
+|#AntiqueWhite|Sistema de Pedidos|
+:Validar estoque;
+
+if (Estoque disponível?) then (sim)
+  :Reservar itens;
+  :Processar pagamento;
+  
+  if (Pagamento aprovado?) then (sim)
+    :Confirmar pedido;
+    :Notificar equipe de logística;
+    |#LightBlue|Logística|
+    :Preparar itens;
+    :Embalar pedido;
+    :Gerar etiqueta de envio;
+    :Entregar para transportadora;
+    |#LightGreen|Transportadora|
+    :Transportar pedido;
+    :Entregar ao cliente;
+    |Cliente|
+    :Receber pedido;
+    :Confirmar recebimento;
+    |#AntiqueWhite|Sistema de Pedidos|
+    :Finalizar pedido;
+    stop
+  else (não)
+    :Notificar falha no pagamento;
+    |Cliente|
+    :Atualizar método de pagamento;
+    repeat
+    :Tentar novamente;
+    |#AntiqueWhite|Sistema de Pedidos|
+    :Processar pagamento;
+    repeat while (Pagamento aprovado?) is (não) not (sim)
+    ->sim;
+  endif
+else (não)
+  :Notificar indisponibilidade;
+  |Cliente|
+  :Receber notificação;
+  if (Aguardar reposição?) then (sim)
+    |#AntiqueWhite|Sistema de Pedidos|
+    :Adicionar à lista de espera;
+    :Notificar quando disponível;
+    |Cliente|
+    :Receber notificação de disponibilidade;
+    ->Confirmar pedido;
+  else (não)
+    :Cancelar pedido;
+    |#AntiqueWhite|Sistema de Pedidos|
+    :Registrar cancelamento;
+    stop
+  endif
+endif
+
+@enduml

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# setup.sh - Script para facilitar a configuração inicial do PlantUML 2 PNG
+# Autor: Tiago N. Pinto Silva
+
+echo "🚀 Iniciando configuração do PlantUML 2 PNG..."
+
+# Verifica se o Java está instalado
+if command -v java &> /dev/null; then
+    JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//' | cut -d'.' -f1)
+    echo "✅ Java encontrado (versão $JAVA_VERSION)"
+else
+    echo "❌ Java não encontrado. Por favor, instale o Java (JRE 8 ou superior)"
+    echo "   Visite: https://www.java.com/download/"
+    exit 1
+fi
+
+# Tornar os scripts executáveis
+echo "📜 Tornando os scripts executáveis..."
+chmod +x plantuml2png.sh batch-convert.sh
+
+# Criar diretório de output se não existir
+if [ ! -d "output" ]; then
+    echo "📁 Criando diretório de saída (output)..."
+    mkdir -p output
+fi
+
+# Verificar se o PlantUML JAR já existe
+PLANTUML_JAR_PATH="$HOME/plantuml.jar"
+if [ -f "$PLANTUML_JAR_PATH" ]; then
+    echo "✅ PlantUML JAR já existe em $PLANTUML_JAR_PATH"
+else
+    echo "🔄 PlantUML JAR não encontrado. O script irá baixá-lo automaticamente na primeira execução."
+fi
+
+# Testar conversão de exemplo
+echo "🧪 Deseja testar a conversão com um exemplo? (S/n)"
+read -r response
+if [[ "$response" =~ ^([sS]|[sS][iI][mM]|"")$ ]]; then
+    # Selecionar um exemplo aleatório
+    RANDOM_EXAMPLE=$(find examples -name "*.wsd" | shuf -n 1)
+    if [ -n "$RANDOM_EXAMPLE" ]; then
+        echo "🔍 Testando com o exemplo: $RANDOM_EXAMPLE"
+        ./plantuml2png.sh -v "$RANDOM_EXAMPLE"
+        
+        # Verificar se a conversão foi bem-sucedida
+        BASE_NAME=$(basename "$RANDOM_EXAMPLE" .wsd)
+        if [ -f "$(dirname "$RANDOM_EXAMPLE")/$BASE_NAME.png" ]; then
+            echo "🎉 Teste concluído com sucesso! Verifique a imagem gerada em $(dirname "$RANDOM_EXAMPLE")/$BASE_NAME.png"
+        fi
+    else
+        echo "⚠️ Nenhum exemplo encontrado no diretório 'examples'"
+    fi
+fi
+
+echo "✨ Configuração concluída! Agora você pode usar o PlantUML 2 PNG para converter seus diagramas."
+echo
+echo "📖 Uso básico:"
+echo "  ./plantuml2png.sh seu-diagrama.wsd        # Converter um arquivo"
+echo "  ./batch-convert.sh                         # Converter todos os arquivos de examples/ para output/"
+echo
+echo "📘 Para mais informações, consulte o README.md"
+
+exit 0


### PR DESCRIPTION
## Melhorias Implementadas

Esta PR adiciona várias melhorias e novas funcionalidades ao conversor PlantUML:

### Atualizações no script principal (`plantuml2png.sh`):

- Atualizado para versão 1.1.0
- Adicionado suporte para múltiplos formatos de saída (PNG, SVG, EPS, PDF)
- Verificação da instalação do Java
- Melhor tratamento de erros
- Opção para configurar caminho personalizado do JAR do PlantUML
- Suporte para arquivo de configuração
- Melhorias na saída e feedback visual

### Atualizações no script de lote (`batch-convert.sh`):

- Atualizado para versão 1.1.0
- Suporte completo para todas as novas opções do script principal
- Reconhecimento de múltiplas extensões de arquivos PlantUML (.wsd, .puml, .plantuml, etc.)
- Melhor tratamento de argumentos da linha de comando
- Feedback visual aprimorado

### Novos arquivos:

- Script de configuração rápida (`setup.sh`) para facilitar a primeira execução
- Arquivo `.gitignore` para manter o repositório limpo
- Exemplo adicional de diagrama de atividades
- Documentação completa no README.md

### Documentação:

- README completamente revisado com exemplos detalhados de uso
- Documentação interna dos scripts aprimorada

Estas melhorias deixam o projeto mais robusto, flexível e fácil de usar, especialmente para novos usuários.